### PR TITLE
Fix unclosed quote in an alt attribute

### DIFF
--- a/css/desktop.css
+++ b/css/desktop.css
@@ -52,12 +52,16 @@ header img {
 input[type="email"] {
     width: 100%;
     -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
 }
 
 .external .col {
     float: left;
     width: 33%;
     -moz-box-sizing: border-box;
+    -webkit-box-sizing: border-box;
+    box-sizing: border-box;
     padding: 10px;
 }
 .external .col:first-child {

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 <body>
 <header>
     <div class="wrapper">
-        <img src="img/logo.jpg" alt="mozilla + US Ignite width="332" height="51" />
+        <img src="img/logo.jpg" alt="mozilla + US Ignite" width="332" height="51" />
         <a class="tab" href="http://www.mozilla.org">mozilla</a>
     </div>
 </header>


### PR DESCRIPTION
Just a minor typo fix that was throwing off TextMate's syntax highlighting. :)
